### PR TITLE
Add FTP deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-ftp.yml
+++ b/.github/workflows/deploy-to-ftp.yml
@@ -1,0 +1,31 @@
+name: Deploy to FTP
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: linux
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4
+        with:
+          server: ftp://194.36.184.209
+          username: ${{ secrets.MFK_FTP_USER }}
+          password: ${{ secrets.MFK_FTP_PASS }}
+          local-dir: ./dist
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and upload the `dist` directory via FTP
- update server to `ftp://194.36.184.209` for deployment

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68582ae4b3a4833197db2bcd1328cea0