### PR TITLE
Add LiveChat component

### DIFF
--- a/src/components/LiveChat.jsx
+++ b/src/components/LiveChat.jsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+export default function LiveChat() {
+    useEffect(() => {
+        const w = window
+        w.Tawk_API = w.Tawk_API || {}
+        w.Tawk_LoadStart = new Date()
+
+        const s1 = document.createElement('script')
+        s1.async = true
+        s1.src = 'https://embed.tawk.to/685f9f82fa020f190dcd7b77/1iuqoe5lq'
+        s1.charset = 'UTF-8'
+        s1.setAttribute('crossorigin', '*')
+
+        const firstScript = document.getElementsByTagName('script')[0]
+        firstScript.parentNode?.insertBefore(s1, firstScript)
+
+        const style = document.createElement('style')
+        style.innerHTML = '#tawkchat-container{bottom:96px!important}'
+        document.head.appendChild(style)
+
+        return () => {
+            s1.remove()
+            style.remove()
+        }
+    }, [])
+
+    return null
+}

--- a/src/layouts/DefaultLayout.jsx
+++ b/src/layouts/DefaultLayout.jsx
@@ -2,6 +2,7 @@
 import NavBar from '@/components/NavBar'
 import Footer from '@/components/Footer'
 import WhatsAppButton from '@/components/WhatsAppButton'
+import LiveChat from '@/components/LiveChat'
 import { locales, defaultLocale } from '@/lib/i18n'
 import '@/App.css'
 
@@ -21,6 +22,7 @@ const DefaultLayout = ({ children, params }) => {
             <NavBar />
             <main className="flex-1">{children}</main>
             <Footer />
+            <LiveChat />
             <WhatsAppButton phone="971508191635" />
         </div>
     )


### PR DESCRIPTION
## Summary
- rename LiveChat component to `.jsx` and remove TypeScript syntax
- ensure chat widget sits above WhatsApp button via injected style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685fa14ac0548331a8dcf2ea11caf2e3