### PR TITLE
Add main headings for SEO

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -24,7 +24,7 @@ const NavBar = () => {
             <div className="container mx-auto px-4 py-4">
                 <div className="flex justify-between items-center">
                     {/* Logo */}
-                    <h1 className="text-2xl font-bold text-mfk-blue">
+                    <div className="text-2xl font-bold text-mfk-blue">
                         <Link to={`/${lang}`}>
                             <img
                                 src='/images/logo_120px.png'
@@ -34,7 +34,7 @@ const NavBar = () => {
                                 alt="شعار الشركة"
                             />
                         </Link>
-                    </h1>
+                    </div>
 
                     {/* Desktop Navigation */}
                     <div className="flex items-center gap-8">

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -15,9 +15,9 @@ const Contact = () => {
             <section id="contact" className="py-16 bg-mfk-blue/5">
                 <div className="container mx-auto px-4">
                     <div className="text-center mb-12">
-                        <h2 className="text-3xl font-bold text-mfk-blue mb-4">
+                        <h1 className="text-3xl font-bold text-mfk-blue mb-4">
                             {t('contact.title')}
-                        </h2>
+                        </h1>
                         <p className="text-gray-700 max-w-2xl mx-auto">
                             {t('contact.description')}
                         </p>

--- a/src/pages/PaintingCalculator.jsx
+++ b/src/pages/PaintingCalculator.jsx
@@ -59,7 +59,7 @@ const PaintingCalculator = () => {
     <DefaultLayout>
       <Seo title="حاسبة تكلفة الدهان - Painting Cost Calculator" />
       <section className="py-16 container mx-auto px-4">
-        <h2 className="text-3xl font-bold text-mfk-blue mb-6 text-center">{t('calculator.title')}</h2>
+        <h1 className="text-3xl font-bold text-mfk-blue mb-6 text-center">{t('calculator.title')}</h1>
         <div className="flex justify-center flex-wrap gap-2 mb-6">
           {progressSteps.map(s => (
             <div

--- a/src/pages/ServiceDetails.jsx
+++ b/src/pages/ServiceDetails.jsx
@@ -36,9 +36,11 @@ const ServiceDetails = () => {
             />
             <section className="py-16 bg-gray-100">
                 <div className="container mx-auto px-4 text-center">
-                    <h3 className="text-3xl font-bold mb-6 text-mfk-blue">
-                        {lang === 'ar' ? selectedService.title : selectedService.title_en}
-                    </h3>
+                    <h1 className="text-3xl font-bold mb-6 text-mfk-blue">
+                        {lang === 'ar'
+                            ? selectedService.title
+                            : selectedService.title_en}
+                    </h1>
                     <img
                         src={selectedService.img}
                         alt={lang === 'ar' ? selectedService.title : selectedService.title_en}


### PR DESCRIPTION
## Summary
- wrap the contact title in `<h1>`
- switch the painting calculator title to `<h1>`
- use a dynamic `<h1>` in ServiceDetails based on the service title
- keep NavBar logo wrapped in a `<div>`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e3c9ab0bc8331b25cf409bf10e74d